### PR TITLE
Add reusable outline-sync config loader and refresh docs

### DIFF
--- a/apps/docs/dockstat/README.md
+++ b/apps/docs/dockstat/README.md
@@ -3,7 +3,7 @@ id: 7dddd764-6483-4f84-96a3-988304e772d3
 title: DockStat
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: null
-updatedAt: 2025-12-17T21:02:58.642Z
+updatedAt: 2025-12-29T20:53:33.126Z
 urlId: zqa4IyZtl0
 ---
 

--- a/apps/docs/dockstat/api-reference/README.md
+++ b/apps/docs/dockstat/api-reference/README.md
@@ -3,7 +3,7 @@ id: b174143d-f906-4f8d-8cb5-9fc96512e575
 title: API Reference
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: 7dddd764-6483-4f84-96a3-988304e772d3
-updatedAt: 2025-12-16T19:16:50.491Z
+updatedAt: 2025-12-29T20:53:27.622Z
 urlId: gVYlljv3Fs
 ---
 

--- a/apps/docs/dockstat/api-reference/frontend-plugin-api-(plugins-frontend)/README.md
+++ b/apps/docs/dockstat/api-reference/frontend-plugin-api-(plugins-frontend)/README.md
@@ -3,7 +3,7 @@ id: 560ed81b-f22c-4a72-ba1d-650d377e885b
 title: Frontend Plugin API (plugins/frontend)
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: b174143d-f906-4f8d-8cb5-9fc96512e575
-updatedAt: 2025-12-23T10:10:53.062Z
+updatedAt: 2025-12-29T20:53:27.992Z
 urlId: mok9JVXj9w
 ---
 

--- a/apps/docs/dockstat/apps-overview/README.md
+++ b/apps/docs/dockstat/apps-overview/README.md
@@ -3,7 +3,7 @@ id: fb89c77f-9f0a-497a-bb24-c41d21b37478
 title: Apps overview
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: 7dddd764-6483-4f84-96a3-988304e772d3
-updatedAt: 2025-12-17T09:47:18.062Z
+updatedAt: 2025-12-29T20:53:32.794Z
 urlId: YM2LlgAuWf
 ---
 

--- a/apps/docs/dockstat/architecture/README.md
+++ b/apps/docs/dockstat/architecture/README.md
@@ -3,7 +3,7 @@ id: d56ca448-563a-4206-9585-c45f8f6be5cf
 title: Architecture
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: 7dddd764-6483-4f84-96a3-988304e772d3
-updatedAt: 2025-12-16T19:17:04.228Z
+updatedAt: 2025-12-29T20:53:27.304Z
 urlId: g3eBa2Z8rL
 ---
 

--- a/apps/docs/dockstat/configuration/README.md
+++ b/apps/docs/dockstat/configuration/README.md
@@ -3,7 +3,7 @@ id: dec1cb2c-9a13-4e67-a31c-d3a685391208
 title: Configuration
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: 7dddd764-6483-4f84-96a3-988304e772d3
-updatedAt: 2025-12-17T09:46:31.595Z
+updatedAt: 2025-12-29T20:53:31.749Z
 urlId: 3dLW6L8pzR
 ---
 

--- a/apps/docs/dockstat/integration-guide/README.md
+++ b/apps/docs/dockstat/integration-guide/README.md
@@ -3,7 +3,7 @@ id: e4e04545-fd9f-4fbf-becb-94da81f48bc5
 title: Integration guide
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: 7dddd764-6483-4f84-96a3-988304e772d3
-updatedAt: 2025-12-17T09:45:45.019Z
+updatedAt: 2025-12-29T20:53:32.118Z
 urlId: SWA5Nd4lzW
 ---
 

--- a/apps/docs/dockstat/packages/@dockstat-db/README.md
+++ b/apps/docs/dockstat/packages/@dockstat-db/README.md
@@ -3,7 +3,7 @@ id: 5176f3ba-1242-4c85-8290-491dcc0f9963
 title: "@dockstat/db"
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: bbcefaa2-6bd4-46e8-ae4b-a6b823593e67
-updatedAt: 2025-12-17T09:12:31.841Z
+updatedAt: 2025-12-29T20:53:28.718Z
 urlId: LgnEA0nOUp
 ---
 

--- a/apps/docs/dockstat/packages/@dockstat-docker-client/README.md
+++ b/apps/docs/dockstat/packages/@dockstat-docker-client/README.md
@@ -3,7 +3,7 @@ id: ef12194c-404e-4bcd-a5b0-31aaf7b1b798
 title: "@dockstat/docker-client"
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: bbcefaa2-6bd4-46e8-ae4b-a6b823593e67
-updatedAt: 2025-12-17T09:16:08.678Z
+updatedAt: 2025-12-29T20:53:29.086Z
 urlId: X0z5b9Ra01
 ---
 

--- a/apps/docs/dockstat/packages/@dockstat-logger/README.md
+++ b/apps/docs/dockstat/packages/@dockstat-logger/README.md
@@ -3,7 +3,7 @@ id: e913e6bd-3f7c-485f-812d-3e626b4f6b5b
 title: "@dockstat/logger"
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: bbcefaa2-6bd4-46e8-ae4b-a6b823593e67
-updatedAt: 2025-12-17T09:49:02.729Z
+updatedAt: 2025-12-29T20:53:29.526Z
 urlId: zb1s366Lti
 ---
 

--- a/apps/docs/dockstat/packages/@dockstat-plugin-handler/README.md
+++ b/apps/docs/dockstat/packages/@dockstat-plugin-handler/README.md
@@ -3,7 +3,7 @@ id: eadaaa93-6c65-4207-a4ac-9b19afc8f2a5
 title: "@dockstat/plugin-handler"
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: bbcefaa2-6bd4-46e8-ae4b-a6b823593e67
-updatedAt: 2025-12-16T19:04:24.453Z
+updatedAt: 2025-12-29T20:53:29.838Z
 urlId: pXHTTOpluB
 ---
 

--- a/apps/docs/dockstat/packages/@dockstat-sqlite-wrapper/README.md
+++ b/apps/docs/dockstat/packages/@dockstat-sqlite-wrapper/README.md
@@ -3,7 +3,7 @@ id: f543683b-68be-431f-a6d5-7b4012b1345a
 title: "@dockstat/sqlite-wrapper"
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: bbcefaa2-6bd4-46e8-ae4b-a6b823593e67
-updatedAt: 2025-12-17T09:19:53.239Z
+updatedAt: 2025-12-29T20:53:28.395Z
 urlId: vCSP0qqnqI
 ---
 

--- a/apps/docs/dockstat/packages/@dockstat-typings/README.md
+++ b/apps/docs/dockstat/packages/@dockstat-typings/README.md
@@ -3,7 +3,7 @@ id: ecb9e07b-37e7-430a-b3fc-eb51515ab9ac
 title: "@dockstat/typings"
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: bbcefaa2-6bd4-46e8-ae4b-a6b823593e67
-updatedAt: 2025-12-16T19:05:51.049Z
+updatedAt: 2025-12-29T20:53:30.259Z
 urlId: 7Ae5a9YIKb
 ---
 

--- a/apps/docs/dockstat/packages/@dockstat-ui/README.md
+++ b/apps/docs/dockstat/packages/@dockstat-ui/README.md
@@ -3,7 +3,7 @@ id: a04555b5-b827-4441-ae20-9cad1a2be714
 title: "@dockstat/ui"
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: bbcefaa2-6bd4-46e8-ae4b-a6b823593e67
-updatedAt: 2025-12-17T09:23:29.497Z
+updatedAt: 2025-12-29T20:53:30.738Z
 urlId: NXWduCaEB3
 ---
 

--- a/apps/docs/dockstat/packages/@dockstat-utils/README.md
+++ b/apps/docs/dockstat/packages/@dockstat-utils/README.md
@@ -3,7 +3,7 @@ id: d3039895-f53c-46ab-89ce-de0ad22ce03c
 title: "@dockstat/utils"
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: bbcefaa2-6bd4-46e8-ae4b-a6b823593e67
-updatedAt: 2025-12-17T09:38:34.988Z
+updatedAt: 2025-12-29T20:53:31.102Z
 urlId: dHg9YfruFJ
 ---
 

--- a/apps/docs/dockstat/packages/README.md
+++ b/apps/docs/dockstat/packages/README.md
@@ -3,7 +3,7 @@ id: bbcefaa2-6bd4-46e8-ae4b-a6b823593e67
 title: Packages
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: 7dddd764-6483-4f84-96a3-988304e772d3
-updatedAt: 2025-12-16T19:07:33.253Z
+updatedAt: 2025-12-29T20:53:31.495Z
 urlId: waARCz3AZ0
 ---
 

--- a/apps/docs/dockstat/troubleshooting/README.md
+++ b/apps/docs/dockstat/troubleshooting/README.md
@@ -3,7 +3,7 @@ id: 88a5f959-3f89-4266-9d8e-eb50193425b0
 title: Troubleshooting
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: 7dddd764-6483-4f84-96a3-988304e772d3
-updatedAt: 2025-12-17T09:44:51.395Z
+updatedAt: 2025-12-29T20:53:32.430Z
 urlId: lgGFKJhiDO
 ---
 

--- a/packages/template-renderer/README.md
+++ b/packages/template-renderer/README.md
@@ -3,7 +3,7 @@ id: 453740d4-b426-423d-98fc-b36f6dff7644
 title: "@dockstat/template-renderer"
 collectionId: b4a5e48f-f103-480b-9f50-8f53f515cab9
 parentDocumentId: bbcefaa2-6bd4-46e8-ae4b-a6b823593e67
-updatedAt: 2025-12-23T12:50:44.974Z
+updatedAt: 2025-12-24T00:36:09.100Z
 urlId: 5qbatLB5V0
 ---
 
@@ -75,7 +75,7 @@ import { TemplateRenderer, parseTemplate } from "@dockstat/template-renderer"
 import { useState } from "react"
 
 function MyPage() {
-  const templateYaml = `...` // Your YAML template
+  const templateYaml = `...`
   const result = parseTemplate(templateYaml, "yaml")
 
   if (!result.success) {
@@ -98,7 +98,6 @@ function MyPage() {
 ### Using the Builder API
 
 ```typescript
-
 import {
   template,
   widgets,
@@ -210,7 +209,6 @@ All widgets from `@dockstat/ui` are available:
 Bind widget props to state or data using the `bindings` property:
 
 ```yaml
-
 widgets:
   - type: text
     props:
@@ -234,7 +232,6 @@ widgets:
 Use the `condition` property to conditionally render widgets:
 
 ```yaml
-
 widgets:
   - type: badge
     props:
@@ -253,7 +250,6 @@ widgets:
 Render widgets for each item in an array:
 
 ```yaml
-
 widgets:
   - type: card
     props:
@@ -276,7 +272,6 @@ widgets:
 Use templates in your DockStat plugins:
 
 ```typescript
-
 import type { PluginFrontendConfig } from "@dockstat/template-renderer"
 
 const frontendConfig: PluginFrontendConfig = {


### PR DESCRIPTION
## Summary by Sourcery

Introduce a reusable configuration discovery and loading utility for outline-sync and refresh synced documentation metadata and examples.

Enhancements:
- Replace the outline-sync CLI entrypoint with a configuration discovery and loading module that supports multiple config file formats and locations.

Documentation:
- Update DockStat and template-renderer documentation metadata and clean up example code formatting.