### PR TITLE
refactor(plugins): use Blob URLs for plugin loading and startup plugin loading

### DIFF
--- a/apps/api/src/plugins/index.ts
+++ b/apps/api/src/plugins/index.ts
@@ -4,7 +4,9 @@ import BaseLogger from "../logger"
 
 const PluginHandler = new PluginHandlerFactory(
   DockStatDB._sqliteWrapper,
-  BaseLogger.getParentsForLoggerChaining()
+  BaseLogger.spawn("PluginHandler")
 )
+
+await PluginHandler.loadAllPlugins()
 
 export default PluginHandler


### PR DESCRIPTION
- Refactors plugin loading mechanism to utilize in-memory Blob objects and `URL.createObjectURL` instead of writing to temporary files. This improves security, performance, and resource management by eliminating filesystem I/O.
- Updates the `PluginHandler` constructor to directly accept a `Logger` instance, simplifying logger configuration and promoting consistency.
- Implements eager loading of all registered plugins during API startup, ensuring plugins are available immediately upon service initialization.

closes #45

## Summary by Sourcery

Refactor plugin loading to use in-memory Blob URLs and eagerly initialize all plugins at API startup.

Enhancements:
- Change PluginHandler to receive a Logger instance directly instead of constructing its own logger.
- Log additional context when loading all plugins, including counts of plugins in the database and already loaded plugins.

Chores:
- Replace temporary filesystem-based plugin loading with Blob URL-based dynamic imports and ensure proper cleanup of created Blob URLs.