### PR TITLE
feat(dockstat): Add custom toast notifications and global error alerts

### DIFF
--- a/apps/dockstat/package.json
+++ b/apps/dockstat/package.json
@@ -24,6 +24,7 @@
     "react-devtools": "^7.0.1",
     "react-dom": "^19.2.3",
     "react-router": "^7.11.0",
+    "sonner": "^2.0.7",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {

--- a/apps/dockstat/src/components/toast.tsx
+++ b/apps/dockstat/src/components/toast.tsx
@@ -1,9 +1,9 @@
 "use client"
 
 import { Button, Card } from "@dockstat/ui"
-import { toast as sonnerToast } from "sonner"
 import { motion } from "framer-motion"
 import { useState } from "react"
+import { toast as sonnerToast } from "sonner"
 
 export function toast(toast: Omit<ToastProps, "id">) {
   return sonnerToast.custom((id) => (

--- a/apps/dockstat/src/components/toast.tsx
+++ b/apps/dockstat/src/components/toast.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { Button, Card } from "@dockstat/ui"
+import { toast as sonnerToast } from "sonner"
+import { motion } from "framer-motion"
+import { useState } from "react"
+
+export function toast(toast: Omit<ToastProps, "id">) {
+  return sonnerToast.custom((id) => (
+    <Toast
+      id={id}
+      title={toast.title}
+      description={toast.description}
+      button={toast.button}
+      variant={toast.variant}
+    />
+  ))
+}
+
+interface ToastProps {
+  id: string | number
+  title: string | React.ReactNode
+  description: string
+  variant?: "error" | "success"
+  button?: {
+    label: string
+    onClick: () => void
+  }
+}
+
+function Toast(props: ToastProps) {
+  const { title, description, button, id, variant } = props
+  const [isHovered, setIsHovered] = useState(false)
+
+  const cardVariant = variant === "error" ? "error" : variant === "success" ? "success" : "outlined"
+
+  return (
+    <motion.div
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      className="relative"
+      style={{ zIndex: isHovered ? 50 : 1 }}
+    >
+      <Card variant={cardVariant} size="sm">
+        <div className="flex items-start gap-4">
+          <motion.div
+            className="min-w-0 flex-1"
+            initial={false}
+            animate={{
+              maxHeight: isHovered ? 1000 : 60,
+            }}
+            transition={{
+              duration: 0.4,
+              ease: [0.4, 0, 0.2, 1],
+            }}
+            style={{ overflow: "hidden" }}
+          >
+            <p
+              className="text-sm font-semibold leading-5 text-primary-text"
+              title={typeof title === "string" ? title : undefined}
+            >
+              {title}
+            </p>
+
+            <p className="mt-1 text-sm leading-5 text-muted-text" title={description}>
+              {description}
+            </p>
+          </motion.div>
+
+          <div className="my-auto shrink-0">
+            <Button
+              variant={cardVariant === "error" ? "danger" : "outline"}
+              className="rounded-md px-3 py-1.5 text-sm font-semibold leading-5 shadow-sm transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2"
+              onClick={() => {
+                button?.onClick()
+                sonnerToast.dismiss(id)
+              }}
+            >
+              {button?.label || "Dismiss"}
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </motion.div>
+  )
+}

--- a/apps/dockstat/src/components/toast.tsx
+++ b/apps/dockstat/src/components/toast.tsx
@@ -1,9 +1,9 @@
 "use client"
 
 import { Button, Card } from "@dockstat/ui"
-import { toast as sonnerToast } from "sonner"
 import { motion } from "framer-motion"
-import { useState } from "react"
+import { type ReactNode, useState } from "react"
+import { toast as sonnerToast } from "sonner"
 
 export function toast(toast: Omit<ToastProps, "id">) {
   return sonnerToast.custom((id) => (
@@ -19,8 +19,8 @@ export function toast(toast: Omit<ToastProps, "id">) {
 
 interface ToastProps {
   id: string | number
-  title: string | React.ReactNode
-  description: string
+  title: string | ReactNode
+  description: string | ReactNode
   variant?: "error" | "success"
   button?: {
     label: string
@@ -62,7 +62,10 @@ function Toast(props: ToastProps) {
               {title}
             </p>
 
-            <p className="mt-1 text-sm leading-5 text-muted-text" title={description}>
+            <p
+              className="mt-1 text-sm leading-5 text-muted-text"
+              title={typeof description === "string" ? description : undefined}
+            >
               {description}
             </p>
           </motion.div>

--- a/apps/dockstat/src/hooks/isLoading.ts
+++ b/apps/dockstat/src/hooks/isLoading.ts
@@ -1,7 +1,0 @@
-import { useIsFetching, useIsMutating } from "@tanstack/react-query"
-
-export function useGlobalBusy() {
-  const busy = useIsFetching() + useIsMutating() > 0
-
-  return busy
-}

--- a/apps/dockstat/src/layout.tsx
+++ b/apps/dockstat/src/layout.tsx
@@ -9,6 +9,8 @@ import { useContext, useEffect, useState } from "react"
 import { AdditionalSettingsContext } from "@/contexts/additionalSettings"
 import { PageHeadingContext } from "./contexts/pageHeadingContext"
 import { useGlobalBusy } from "./hooks/useGlobalBusy"
+import { toast } from "./components/toast"
+import { Toaster } from "sonner"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const qc = useQueryClient()
@@ -58,10 +60,23 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       arrayUtils.pushWithLimit<LogEntry>(next, logMessage)
       return next
     })
+
+    if (logMessage.level === "error") {
+      toast({
+        variant: "error",
+        title: (
+          <p>
+            A server error occured! [<span className="text-accent">{logMessage.name}</span>]
+          </p>
+        ),
+        description: logMessage.message,
+      })
+    }
   }, [logMessage])
 
   return (
     <div className="bg-main-bg min-h-screen w-screen p-4">
+      <Toaster expand position="bottom-right" />
       <Navbar
         isBusy={isBusy}
         navLinks={navLinks}

--- a/apps/dockstat/src/layout.tsx
+++ b/apps/dockstat/src/layout.tsx
@@ -6,11 +6,11 @@ import { Navbar } from "@dockstat/ui"
 import { arrayUtils } from "@dockstat/utils"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useContext, useEffect, useState } from "react"
+import { Toaster } from "sonner"
 import { AdditionalSettingsContext } from "@/contexts/additionalSettings"
+import { toast } from "./components/toast"
 import { PageHeadingContext } from "./contexts/pageHeadingContext"
 import { useGlobalBusy } from "./hooks/useGlobalBusy"
-import { toast } from "./components/toast"
-import { Toaster } from "sonner"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const qc = useQueryClient()

--- a/apps/dockstat/src/layout.tsx
+++ b/apps/dockstat/src/layout.tsx
@@ -6,11 +6,11 @@ import { Navbar } from "@dockstat/ui"
 import { arrayUtils } from "@dockstat/utils"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useContext, useEffect, useState } from "react"
+import { Toaster } from "sonner"
 import { AdditionalSettingsContext } from "@/contexts/additionalSettings"
+import { toast } from "./components/toast"
 import { PageHeadingContext } from "./contexts/pageHeadingContext"
 import { useGlobalBusy } from "./hooks/useGlobalBusy"
-import { toast } from "./components/toast"
-import { Toaster } from "sonner"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const qc = useQueryClient()
@@ -66,7 +66,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         variant: "error",
         title: (
           <p>
-            A server error occured! [<span className="text-accent">{logMessage.name}</span>]
+            A server error occurred! [<span className="text-accent">{logMessage.name}</span>]
           </p>
         ),
         description: logMessage.message,

--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,7 @@
         "react-devtools": "^7.0.1",
         "react-dom": "^19.2.3",
         "react-router": "^7.11.0",
+        "sonner": "^2.0.7",
         "tailwindcss": "^4.1.18",
       },
       "devDependencies": {

--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -1,7 +1,15 @@
 import type React from "react"
 import type { MouseEventHandler, ReactNode } from "react"
 
-export type CardVariant = "default" | "outlined" | "elevated" | "flat" | "dark"
+export type CardVariant =
+  | "default"
+  | "outlined"
+  | "elevated"
+  | "flat"
+  | "dark"
+  | "error"
+  | "success"
+
 export type CardSize = "xs" | "sm" | "md" | "lg"
 
 export interface CardProps {
@@ -29,6 +37,8 @@ export const Card: React.FC<CardProps> = ({
     elevated: "bg-card-elevated-bg shadow-2xl text-primary-text",
     flat: "bg-card-flat-bg border-none text-muted-text",
     dark: "border border-card-outlined-border/20 bg-main-bg text-secondary-text",
+    error: "border border-error bg-main-bg text-secondary-text",
+    success: "border border-success bg-main-bg text-secondary-text",
   }
 
   const sizeClasses: Record<CardSize, string> = {


### PR DESCRIPTION
## Summary by Sourcery

Introduce a custom toast notification system for Dockstat and hook it into global server error logging.

New Features:
- Add a reusable animated toast component powered by Sonner and the shared Card/Button UI components.
- Display a global toast notification when a server log entry with error level is emitted.

Enhancements:
- Extend the shared Card component with error and success variants for status-styled surfaces.

Build:
- Add the Sonner toast library as a Dockstat app dependency.

Chores:
- Remove the unused isLoading hook from the Dockstat app.