### PR TITLE
refactor(page-heading): Use useEffect for setting page titles

### DIFF
--- a/apps/dockstat/src/components/clients/HostsList.tsx
+++ b/apps/dockstat/src/components/clients/HostsList.tsx
@@ -1,4 +1,4 @@
-import { Badge, Card, CardBody, CardHeader } from "@dockstat/ui"
+import { Badge, Card } from "@dockstat/ui"
 import { Globe, Server } from "lucide-react"
 
 interface Host {

--- a/apps/dockstat/src/components/clients/PoolStatsCard.tsx
+++ b/apps/dockstat/src/components/clients/PoolStatsCard.tsx
@@ -1,4 +1,4 @@
-import { Card, CardBody, CardHeader } from "@dockstat/ui"
+import { Card } from "@dockstat/ui"
 import { Activity, Box, Cpu, Users } from "lucide-react"
 
 interface PoolMetrics {

--- a/apps/dockstat/src/hooks/locations.ts
+++ b/apps/dockstat/src/hooks/locations.ts
@@ -1,7 +1,0 @@
-import { useLocation } from "react-router"
-
-export function useCurrentLocation() {
-  const location = useLocation()
-
-  return location
-}

--- a/apps/dockstat/src/hooks/useHeading.ts
+++ b/apps/dockstat/src/hooks/useHeading.ts
@@ -1,0 +1,10 @@
+import { useContext, useEffect } from "react"
+import { PageHeadingContext } from "@/contexts/pageHeadingContext"
+
+export function usePageHeading(title: string): void {
+  const { setHeading } = useContext(PageHeadingContext)
+
+  useEffect(() => {
+    setHeading(title)
+  }, [setHeading, title])
+}

--- a/apps/dockstat/src/pages/clients/configure.tsx
+++ b/apps/dockstat/src/pages/clients/configure.tsx
@@ -1,19 +1,14 @@
 import { Card, CardBody, Divider, Slides } from "@dockstat/ui"
 import { useQuery } from "@tanstack/react-query"
 import { Plus, Split } from "lucide-react"
-import { useContext, useEffect } from "react"
 import { ClientCard, HostsList } from "@/components/clients"
 import { AddClient } from "@/components/clients/configure/AddClient"
 import { AddHost } from "@/components/clients/configure/AddHost"
-import { PageHeadingContext } from "@/contexts/pageHeadingContext"
+import { usePageHeading } from "@/hooks/useHeading"
 import { fetchClients, fetchHosts, fetchPoolStatus } from "@/lib/queries"
 
 export default function ConfigureClientsPage() {
-  const { setHeading } = useContext(PageHeadingContext)
-
-  useEffect(() => {
-    setHeading("Configure Clients & Hosts")
-  }, [setHeading])
+  usePageHeading("Configure Clients & Hosts")
 
   const { data: clientsData } = useQuery({
     queryKey: ["fetchDockerClients"],

--- a/apps/dockstat/src/pages/clients/index.tsx
+++ b/apps/dockstat/src/pages/clients/index.tsx
@@ -1,7 +1,7 @@
 import { Card, Divider } from "@dockstat/ui"
 import { useQuery } from "@tanstack/react-query"
 import { Hammer, Split } from "lucide-react"
-import { useContext } from "react"
+import { useContext, useEffect } from "react"
 import { ClientCard } from "@/components/clients/ClientCard"
 import { HostsList } from "@/components/clients/HostsList"
 import { PoolStatsCard } from "@/components/clients/PoolStatsCard"
@@ -10,7 +10,11 @@ import { PageHeadingContext } from "@/contexts/pageHeadingContext"
 import { fetchClients, fetchHosts, fetchPoolStatus } from "@/lib/queries"
 
 export default function ClientsPage() {
-  useContext(PageHeadingContext).setHeading("Clients & Workers")
+  const { setHeading } = useContext(PageHeadingContext)
+
+  useEffect(() => {
+    setHeading("Clients & Workers")
+  }, [setHeading])
 
   const { data: clientsData, isLoading: clientsLoading } = useQuery({
     queryKey: ["fetchDockerClients"],

--- a/apps/dockstat/src/pages/clients/index.tsx
+++ b/apps/dockstat/src/pages/clients/index.tsx
@@ -1,20 +1,15 @@
 import { Card, Divider } from "@dockstat/ui"
 import { useQuery } from "@tanstack/react-query"
 import { Hammer, Split } from "lucide-react"
-import { useContext, useEffect } from "react"
 import { ClientCard } from "@/components/clients/ClientCard"
 import { HostsList } from "@/components/clients/HostsList"
 import { PoolStatsCard } from "@/components/clients/PoolStatsCard"
 import { WorkersTable } from "@/components/clients/WorkersTable"
-import { PageHeadingContext } from "@/contexts/pageHeadingContext"
+import { usePageHeading } from "@/hooks/useHeading"
 import { fetchClients, fetchHosts, fetchPoolStatus } from "@/lib/queries"
 
 export default function ClientsPage() {
-  const { setHeading } = useContext(PageHeadingContext)
-
-  useEffect(() => {
-    setHeading("Clients & Workers")
-  }, [setHeading])
+  usePageHeading("Clients & Workers")
 
   const { data: clientsData, isLoading: clientsLoading } = useQuery({
     queryKey: ["fetchDockerClients"],

--- a/apps/dockstat/src/pages/extensions/plugins.tsx
+++ b/apps/dockstat/src/pages/extensions/plugins.tsx
@@ -4,8 +4,8 @@ import { Badge, Button, Card, Divider, Input, LinkWithIcon, Modal } from "@docks
 import { repo } from "@dockstat/utils"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link } from "lucide-react"
-import { useContext, useEffect, useMemo, useState } from "react"
-import { PageHeadingContext } from "@/contexts/pageHeadingContext"
+import { useMemo, useState } from "react"
+import { usePageHeading } from "@/hooks/useHeading"
 import { toast } from "@/lib/toast"
 
 const parseRepoLink = repo.parseFromDBToRepoLink
@@ -31,11 +31,7 @@ type AvailablePlugin = {
 }
 
 export default function PluginBrowser() {
-  const { setHeading } = useContext(PageHeadingContext)
-
-  useEffect(() => {
-    setHeading("Plugin Browser")
-  }, [setHeading])
+  usePageHeading("Plugin Browser")
 
   const qc = useQueryClient()
   const [selectedRepo, setSelectedRepo] = useState<string>("all")

--- a/apps/dockstat/src/pages/extensions/plugins.tsx
+++ b/apps/dockstat/src/pages/extensions/plugins.tsx
@@ -4,7 +4,7 @@ import { Badge, Button, Card, Divider, Input, LinkWithIcon, Modal } from "@docks
 import { repo } from "@dockstat/utils"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link } from "lucide-react"
-import { useContext, useMemo, useState } from "react"
+import { useContext, useEffect, useMemo, useState } from "react"
 import { PageHeadingContext } from "@/contexts/pageHeadingContext"
 import { toast } from "@/lib/toast"
 
@@ -31,7 +31,11 @@ type AvailablePlugin = {
 }
 
 export default function PluginBrowser() {
-  useContext(PageHeadingContext).setHeading("Plugin Browser")
+  const { setHeading } = useContext(PageHeadingContext)
+
+  useEffect(() => {
+    setHeading("Plugin Browser")
+  }, [setHeading])
 
   const qc = useQueryClient()
   const [selectedRepo, setSelectedRepo] = useState<string>("all")

--- a/apps/dockstat/src/pages/index.tsx
+++ b/apps/dockstat/src/pages/index.tsx
@@ -1,15 +1,10 @@
 import { fetchBackendStatus } from "@Queries"
 import { Badge, type BadgeVariant, Card, Divider } from "@dockstat/ui"
 import { useQuery } from "@tanstack/react-query"
-import { useContext, useEffect } from "react"
-import { PageHeadingContext } from "@/contexts/pageHeadingContext"
+import { usePageHeading } from "@/hooks/useHeading"
 
 export default function IndexPage() {
-  const { setHeading } = useContext(PageHeadingContext)
-
-  useEffect(() => {
-    setHeading("Home")
-  }, [setHeading])
+  usePageHeading("Home")
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["fetchBackendStatus"],

--- a/apps/dockstat/src/pages/index.tsx
+++ b/apps/dockstat/src/pages/index.tsx
@@ -1,11 +1,15 @@
 import { fetchBackendStatus } from "@Queries"
 import { Badge, type BadgeVariant, Card, Divider } from "@dockstat/ui"
 import { useQuery } from "@tanstack/react-query"
-import { useContext } from "react"
+import { useContext, useEffect } from "react"
 import { PageHeadingContext } from "@/contexts/pageHeadingContext"
 
 export default function IndexPage() {
-  useContext(PageHeadingContext).setHeading("Home")
+  const { setHeading } = useContext(PageHeadingContext)
+
+  useEffect(() => {
+    setHeading("Home")
+  }, [setHeading])
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["fetchBackendStatus"],

--- a/apps/dockstat/src/pages/pluginId.tsx
+++ b/apps/dockstat/src/pages/pluginId.tsx
@@ -2,9 +2,8 @@ import { TemplateRenderer } from "@dockstat/template-renderer"
 import { Card } from "@dockstat/ui"
 import { motion } from "framer-motion"
 import { AlertTriangle, ArrowLeft, FileX, Home, Loader2, Search } from "lucide-react"
-import { useContext, useEffect } from "react"
 import { useNavigate } from "react-router"
-import { PageHeadingContext } from "@/contexts/pageHeadingContext"
+import { usePageHeading } from "@/hooks/useHeading"
 import { usePluginPage } from "@/hooks/usePluginPage"
 
 export default function PluginIdPage() {
@@ -23,12 +22,9 @@ export default function PluginIdPage() {
     handleNavigate,
   } = usePluginPage()
 
-  const { setHeading } = useContext(PageHeadingContext)
   const heading = data?.route?.meta?.title ? data.route.meta.title : `/p/${pluginId}/${routePath}`
 
-  useEffect(() => {
-    setHeading(heading)
-  }, [setHeading, heading])
+  usePageHeading(heading)
 
   // Animation variants
   const cardVariants = {

--- a/apps/dockstat/src/pages/pluginId.tsx
+++ b/apps/dockstat/src/pages/pluginId.tsx
@@ -2,7 +2,7 @@ import { TemplateRenderer } from "@dockstat/template-renderer"
 import { Card } from "@dockstat/ui"
 import { motion } from "framer-motion"
 import { AlertTriangle, ArrowLeft, FileX, Home, Loader2, Search } from "lucide-react"
-import { useContext } from "react"
+import { useContext, useEffect } from "react"
 import { useNavigate } from "react-router"
 import { PageHeadingContext } from "@/contexts/pageHeadingContext"
 import { usePluginPage } from "@/hooks/usePluginPage"
@@ -23,9 +23,12 @@ export default function PluginIdPage() {
     handleNavigate,
   } = usePluginPage()
 
-  useContext(PageHeadingContext).setHeading(
-    data?.route?.meta?.title ? data.route.meta.title : `/p/${pluginId}/${routePath}`
-  )
+  const { setHeading } = useContext(PageHeadingContext)
+  const heading = data?.route?.meta?.title ? data.route.meta.title : `/p/${pluginId}/${routePath}`
+
+  useEffect(() => {
+    setHeading(heading)
+  }, [setHeading, heading])
 
   // Animation variants
   const cardVariants = {


### PR DESCRIPTION
Moved the `setHeading` calls from `PageHeadingContext` into `useEffect` hooks across various pages.

Previously, `setHeading` was invoked directly during the component's render phase. While often appearing to work, this can lead to subtle bugs, unnecessary re-renders, or warnings in strict mode, as it is a side effect.

By wrapping `setHeading` in `useEffect`, we ensure that:
- The heading is set only after the component mounts.
- It re-sets only when its dependencies (e.g., `setHeading` function itself, or the derived `heading` variable in `pluginId.tsx`) change.
- This aligns with React's best practices for managing side effects, improving component stability and preventing potential issues with render cycles.

## Summary by Sourcery

Enhancements:
- Move PageHeadingContext setHeading calls in multiple pages into useEffect hooks so headings are applied after mount and update only when their dependencies change.